### PR TITLE
feature(px4-sim): use gazebo9 instead of gazebo8

### DIFF
--- a/Formula/px4-sim.rb
+++ b/Formula/px4-sim.rb
@@ -10,7 +10,7 @@ class Px4Sim < Formula
   depends_on "glog"
   depends_on "graphviz"
   depends_on "opencv"
-  depends_on "osrf/simulation/gazebo8"
+  depends_on "osrf/simulation/gazebo9"
   depends_on "protobuf"
   depends_on "px4-dev"
   depends_on :x11


### PR DESCRIPTION
Gazebo 8 is EOL and no bottles will be built for it; use gazebo9 instead.